### PR TITLE
feat: account for lambda doubling in branch indices, improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GEDISABRES 
 
-GEDISABRES /ˈdʒɛdaɪ ˈseɪbɚz/ (Generalized Diatomic Simulation for Absorption and Rovibronic Emission Spectra) is a general-purpose tool for simulating the rovibronic spectra of diatomic molecules. Built using NumPy, Polars, PySide6, PyQtGraph, and SciPy, GEDISABRES is designed to be easily understood and modified.
+GEDISABRES [/ˈdʒɛdaɪ ˈseɪbɚz/](https://ipa-reader.com/?text=ˈdʒɛdaɪ ˈseɪbɚz&voice=Matthew) (Generalized Diatomic Simulation for Absorption and Rovibronic Emission Spectra) is a general-purpose tool for simulating the rovibronic spectra of diatomic molecules. Built using NumPy, Polars, PySide6, PyQtGraph, and SciPy, GEDISABRES is designed to be easily understood and modified.
 
 The capabilities of this tool are briefly summarized below. More detailed theory and notation are explained in the included document.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GEDISABRES 
 
-GEDISABRES (Generalized Diatomic Simulation for Absorption and Rovibronic Emission Spectra) is a general-purpose tool for simulating the rovibronic spectra of diatomic molecules. Built using NumPy, Polars, PySide6, PyQtGraph, and SciPy, GEDISABRES is designed to be easily understood and modified.
+GEDISABRES /ˈdʒɛdaɪ ˈseɪbɚz/ (Generalized Diatomic Simulation for Absorption and Rovibronic Emission Spectra) is a general-purpose tool for simulating the rovibronic spectra of diatomic molecules. Built using NumPy, Polars, PySide6, PyQtGraph, and SciPy, GEDISABRES is designed to be easily understood and modified.
 
 The capabilities of this tool are briefly summarized below. More detailed theory and notation are explained in the included document.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GEDISABRES 
 
-GEDISABRES [/ˈdʒɛdaɪ ˈseɪbɚz/](https://ipa-reader.com/?text=ˈdʒɛdaɪ ˈseɪbɚz&voice=Matthew) (Generalized Diatomic Simulation for Absorption and Rovibronic Emission Spectra) is a general-purpose tool for simulating the rovibronic spectra of diatomic molecules. Built using NumPy, Polars, PySide6, PyQtGraph, and SciPy, GEDISABRES is designed to be easily understood and modified.
+GEDISABRES [/ˈdʒɛdaɪ ˈseɪbɚz/](https://ipa-reader.com/?text=ˈdʒɛdaɪˈseɪbɚz&voice=Matthew) (Generalized Diatomic Simulation for Absorption and Rovibronic Emission Spectra) is a general-purpose tool for simulating the rovibronic spectra of diatomic molecules. Built using NumPy, Polars, PySide6, PyQtGraph, and SciPy, GEDISABRES is designed to be easily understood and modified.
 
 The capabilities of this tool are briefly summarized below. More detailed theory and notation are explained in the included document.
 

--- a/docs/chapters/lineshapes.tex
+++ b/docs/chapters/lineshapes.tex
@@ -39,7 +39,7 @@ Full widths of Gaussian profiles must be summed in quadrature such that \cite[36
 The Voigt profile is a convolution of the Gaussian and Lorentzian profiles.
 The PDF for the Voigt profile is
 \begin{equation*}
-    \phi_V(\nu) = \frac{1}{\sigma\sqrt{2\pi}}\Re[w(z)],
+    \phi_V(\nu) = \frac{1}{\sigma\sqrt{2\pi}}\real[w(z)],
 \end{equation*}
 where
 \begin{equation*}

--- a/docs/gedisabres.bib
+++ b/docs/gedisabres.bib
@@ -1,5 +1,5 @@
 @article{amiotMagneticDipole1Dg1981,
-  title = {The {{Magnetic Dipole}} {\mkbibemph{a}} {\textsuperscript{1}}{{Δ}}{\textsubscript{g}} → {{{\mkbibemph{X}}}} {\textsuperscript{3}}{{Σ}}{\textsubscript{g}}{\textsuperscript{−}} {{Transition}} in the {{Oxygen Afterglow}}},
+  title = {The {{Magnetic Dipole}} {\mkbibemph{a}} {\textsuperscript{1}}{{$\Delta$}}{\textsubscript{g}} {$\rightarrow$} {{{\mkbibemph{X}}}} {\textsuperscript{3}}{{$\Sigma$}}{\textsubscript{g}}{\textsuperscript{-}} {{Transition}} in the {{Oxygen Afterglow}}},
   author = {Amiot, C. and Verges, J.},
   date = {1981-10-01},
   journaltitle = {Canadian Journal of Physics},
@@ -29,7 +29,7 @@
 
 @article{babouHighTemperatureNonequilibriumPartition2009,
   title = {High-{{Temperature}} and {{Nonequilibrium Partition Function}} and {{Thermodynamic Data}} of {{Diatomic Molecules}}},
-  author = {Babou, Y. and family=Rivière, given=Ph., given-i={{Ph}} and Perrin, M.-Y. and Soufiani, A.},
+  author = {Babou, Y. and family=Rivi\`ere, given=Ph., given-i={{Ph}} and Perrin, M.-Y. and Soufiani, A.},
   date = {2009-04},
   journaltitle = {International Journal of Thermophysics},
   shortjournal = {Int. J. Thermophys.},
@@ -56,7 +56,7 @@
 }
 
 @article{brownHigherOrderFineStructure1981,
-  title = {Higher-{{Order Fine Structure}} of the {\mkbibemph{a}} {\textsuperscript{4}}{{Π State}} of {{O}}{\textsubscript{2}}{\textsuperscript{+}}},
+  title = {Higher-{{Order Fine Structure}} of the {\mkbibemph{a}} {\textsuperscript{4}}{{$\Pi$ State}} of {{O}}{\textsubscript{2}}{\textsuperscript{+}}},
   author = {Brown, J.M. and Milton, D.J. and Watson, J.K.G. and Zare, R.N. and Albritton, D.L. and Horani, M. and Rostas, J.},
   date = {1981-11},
   journaltitle = {Journal of Molecular Spectroscopy},
@@ -72,7 +72,7 @@
 }
 
 @article{brownLambdaTypeDoublingParameters1979,
-  title = {Lambda-{{Type Doubling Parameters}} for {{Molecules}} in {{Π Electronic States}} of {{Triplet}} and {{Higher Multiplicity}}},
+  title = {Lambda-{{Type Doubling Parameters}} for {{Molecules}} in {{$\Pi$ Electronic States}} of {{Triplet}} and {{Higher Multiplicity}}},
   author = {Brown, J.M. and Merer, A.J.},
   date = {1979-03},
   journaltitle = {Journal of Molecular Spectroscopy},
@@ -88,7 +88,7 @@
 }
 
 @article{brownLTypeDoublingParameters1987,
-  title = {Λ-{{Type Doubling Parameters}} for {{Molecules}} in {{Δ Electronic States}}},
+  title = {{$\Lambda$}-{{Type Doubling Parameters}} for {{Molecules}} in {{$\Delta$ Electronic States}}},
   author = {Brown, J.M and Cheung, A.S-C and Merer, A.J},
   date = {1987-08},
   journaltitle = {Journal of Molecular Spectroscopy},
@@ -129,9 +129,9 @@
 }
 
 @article{cheungFourierTransformSpectroscopy1984,
-  title = {Fourier {{Transform Spectroscopy}} of {{CrO}}: {{Rotational Analysis}} of the {{{\mkbibemph{A}}}} {\textsuperscript{5}}{{Σ}}−{{{\mkbibemph{X}}}} {\textsuperscript{5}}{{Π}} (0,0) {{Band Near}} 8000 Cm{\textsuperscript{−1}}},
+  title = {Fourier {{Transform Spectroscopy}} of {{CrO}}: {{Rotational Analysis}} of the {{{\mkbibemph{A}}}} {\textsuperscript{5}}{{$\Sigma$}}--{{{\mkbibemph{X}}}} {\textsuperscript{5}}{{$\Pi$}} (0,0) {{Band Near}} 8000 Cm{\textsuperscript{-1}}},
   shorttitle = {Fourier Transform Spectroscopy of {{CrO}}},
-  author = {Cheung, A.S-C. and Żyrnicki, W. and Merer, A.J.},
+  author = {Cheung, A.S-C. and \.Zyrnicki, W. and Merer, A.J.},
   date = {1984-04},
   journaltitle = {Journal of Molecular Spectroscopy},
   shortjournal = {J. Mol. Spectrosc.},
@@ -146,8 +146,8 @@
 }
 
 @article{cheungMolecularSpectroscopicConstants1986,
-  title = {Molecular {{Spectroscopic Constants}} of {{O}}{\textsubscript{2}} ({{{\mkbibemph{B}}}} {\textsuperscript{3}}{{Σ}}{\textsuperscript{–}}): {{The Upper State}} of the {{Schumann}}–{{Runge Bands}}},
-  shorttitle = {Molecular Spectroscopic Constants of {{O2}}({{B3Σ}}−)},
+  title = {Molecular {{Spectroscopic Constants}} of {{O}}{\textsubscript{2}} ({{{\mkbibemph{B}}}} {\textsuperscript{3}}{{$\Sigma$}}{\textsuperscript{--}}): {{The Upper State}} of the {{Schumann}}--{{Runge Bands}}},
+  shorttitle = {Molecular Spectroscopic Constants of {{O2}}({{B3$\Sigma$}}-)},
   author = {Cheung, A.S.-C. and Yoshino, K. and Parkinson, W.H. and Freeman, D.E.},
   date = {1986-09},
   journaltitle = {Journal of Molecular Spectroscopy},
@@ -175,7 +175,7 @@
 
 @book{demtroderLaserSpectroscopy2008,
   title = {Laser {{Spectroscopy}}},
-  author = {Demtröder, Wolfgang},
+  author = {Demtr\"oder, Wolfgang},
   date = {2008},
   publisher = {Springer-Verlag Berlin Heidelberg},
   location = {Berlin, Germany},
@@ -187,7 +187,7 @@
 }
 
 @inproceedings{diskin3LevelModelSchumann1996,
-  title = {A 3-{{Level Model}} for {{Schumann}}–{{Runge O}}{\textsubscript{2}} {{Laser-Induced Fluorescence}}},
+  title = {A 3-{{Level Model}} for {{Schumann}}--{{Runge O}}{\textsubscript{2}} {{Laser-Induced Fluorescence}}},
   booktitle = {Fluid {{Dynamics Conference}}},
   author = {Diskin, Glenn and Lempert, Walter and Miles, Richard},
   date = {1996-06-17},
@@ -226,7 +226,7 @@
   title = {Spectroscopy and {{Optical Diagnostics}} for {{Gases}}},
   author = {Hanson, Ronald K. and Spearrin, R. Mitchell and Goldenstein, Christopher S.},
   date = {2016},
-  series = {{{SpringerLink Bücher}}},
+  series = {{{SpringerLink B\"ucher}}},
   publisher = {Springer},
   location = {Cham, Switzerland},
   doi = {10.1007/978-3-319-23252-2},
@@ -236,7 +236,7 @@
 }
 
 @mvbook{herzbergMolecularSpectraMolecular1950,
-  title = {Molecular {{Spectra}} and {{Molecular Structure}}: {{Volume I}} – {{Spectra}} of {{Diatomic Molecules}}},
+  title = {Molecular {{Spectra}} and {{Molecular Structure}}: {{Volume I}} -- {{Spectra}} of {{Diatomic Molecules}}},
   author = {Herzberg, Gerhard},
   date = {1950},
   edition = {2},
@@ -295,7 +295,7 @@
 @book{kovacsRotationalStructureSpectra1969,
   title = {Rotational {{Structure}} in the {{Spectra}} of {{Diatomic Molecules}}},
   shorttitle = {Rotational Structure in the Spectra of Diatomic Molecules},
-  author = {Kovács, István},
+  author = {Kov\'acs, Istv\'an},
   date = {1969},
   publisher = {Hilger},
   location = {London, England},
@@ -305,7 +305,7 @@
 }
 
 @article{lauxArraysRadiativeTransition1992,
-  title = {Arrays of {{Radiative Transition Probabilities}} for the {{N}}{\textsubscript{2}} {{First}} and {{Second Positive}}, {{NO Beta}} and {{Gamma}}, {{N}}{\textsubscript{2}}{\textsuperscript{+}} {{First Negative}}, and {{O}}{\textsubscript{2}} {{Schumann}}–{{Runge Band Systems}}},
+  title = {Arrays of {{Radiative Transition Probabilities}} for the {{N}}{\textsubscript{2}} {{First}} and {{Second Positive}}, {{NO Beta}} and {{Gamma}}, {{N}}{\textsubscript{2}}{\textsuperscript{+}} {{First Negative}}, and {{O}}{\textsubscript{2}} {{Schumann}}--{{Runge Band Systems}}},
   author = {Laux, Christophe O. and Kruger, Charles H.},
   date = {1992-07},
   journaltitle = {Journal of Quantitative Spectroscopy \& Radiative Transfer},
@@ -322,7 +322,7 @@
 
 @book{lefebvre-brionSpectraDynamicsDiatomic2004,
   title = {The {{Spectra}} and {{Dynamics}} of {{Diatomic Molecules}}},
-  author = {Lefebvre-Brion, Hélène and Field, Robert W.},
+  author = {Lefebvre-Brion, H\'el\`ene and Field, Robert W.},
   date = {2004},
   publisher = {Academic Press},
   doi = {10.1016/B978-0-12-441455-6.X5000-8},
@@ -343,20 +343,20 @@
 }
 
 @online{nistDiatomicSpectralDatabase2018,
-  title = {Diatomic {{Spectral Database}}, {\textsuperscript{1}}{{Σ-Ground State Molecules}}},
+  title = {Diatomic {{Spectral Database}}, {\textsuperscript{3}}{{$\Sigma$-Ground State Molecules}}},
   author = {NIST},
-  date = {2018-04-24},
-  url = {https://www.nist.gov/pml/diatomic-spectral-database/diatomic-spectral-database-1s-ground-state-molecules},
+  date = {2018-04-26},
+  url = {https://www.nist.gov/pml/diatomic-spectral-database/diatomic-spectral-database-3s-ground-state-molecules},
   urldate = {2025-10-05},
   langid = {english},
   annotation = {Last Modified: 2025-02-19T11:17-05:00}
 }
 
 @online{nistDiatomicSpectralDatabase2018a,
-  title = {Diatomic {{Spectral Database}}, {\textsuperscript{3}}{{Σ-Ground State Molecules}}},
+  title = {Diatomic {{Spectral Database}}, {\textsuperscript{1}}{{$\Sigma$-Ground State Molecules}}},
   author = {NIST},
-  date = {2018-04-26},
-  url = {https://www.nist.gov/pml/diatomic-spectral-database/diatomic-spectral-database-3s-ground-state-molecules},
+  date = {2018-04-24},
+  url = {https://www.nist.gov/pml/diatomic-spectral-database/diatomic-spectral-database-1s-ground-state-molecules},
   urldate = {2025-10-05},
   langid = {english},
   annotation = {Last Modified: 2025-02-19T11:17-05:00}
@@ -405,7 +405,7 @@
 }
 
 @article{tatumHonlLondonFactors1966,
-  title = {Hönl–{{London Factors}} for {\textsuperscript{3}}{{Σ}}{\textsuperscript{±}} −{\textsuperscript{3}}{{Σ}}{\textsuperscript{±}} {{Transitions}}},
+  title = {H\"onl--{{London Factors}} for {\textsuperscript{3}}{{$\Sigma$}}{\textsuperscript{\textpm}}--{\textsuperscript{3}}{{$\Sigma$}}{\textsuperscript{\textpm}} {{Transitions}}},
   author = {Tatum, J. B.},
   date = {1966-11-01},
   journaltitle = {Canadian Journal of Physics},

--- a/docs/gedisabres.bib
+++ b/docs/gedisabres.bib
@@ -1,5 +1,5 @@
 @article{amiotMagneticDipole1Dg1981,
-  title = {The {{Magnetic Dipole}} {\mkbibemph{a}} {\textsuperscript{1}}{{$\Delta$}}{\textsubscript{g}} {$\rightarrow$} {{{\mkbibemph{X}}}} {\textsuperscript{3}}{{$\Sigma$}}{\textsubscript{g}}{\textsuperscript{-}} {{Transition}} in the {{Oxygen Afterglow}}},
+  title = {The {{Magnetic Dipole}} {\mkbibemph{a}} {\textsuperscript{1}}{{Δ}}{\textsubscript{g}} → {{{\mkbibemph{X}}}} {\textsuperscript{3}}{{Σ}}{\textsubscript{g}}{\textsuperscript{−}} {{Transition}} in the {{Oxygen Afterglow}}},
   author = {Amiot, C. and Verges, J.},
   date = {1981-10-01},
   journaltitle = {Canadian Journal of Physics},
@@ -29,7 +29,7 @@
 
 @article{babouHighTemperatureNonequilibriumPartition2009,
   title = {High-{{Temperature}} and {{Nonequilibrium Partition Function}} and {{Thermodynamic Data}} of {{Diatomic Molecules}}},
-  author = {Babou, Y. and family=Rivi\`ere, given=Ph., given-i={{Ph}} and Perrin, M.-Y. and Soufiani, A.},
+  author = {Babou, Y. and family=Rivière, given=Ph., given-i={{Ph}} and Perrin, M.-Y. and Soufiani, A.},
   date = {2009-04},
   journaltitle = {International Journal of Thermophysics},
   shortjournal = {Int. J. Thermophys.},
@@ -56,7 +56,7 @@
 }
 
 @article{brownHigherOrderFineStructure1981,
-  title = {Higher-{{Order Fine Structure}} of the {\mkbibemph{a}} {\textsuperscript{4}}{{$\Pi$ State}} of {{O}}{\textsubscript{2}}{\textsuperscript{+}}},
+  title = {Higher-{{Order Fine Structure}} of the {\mkbibemph{a}} {\textsuperscript{4}}{{Π State}} of {{O}}{\textsubscript{2}}{\textsuperscript{+}}},
   author = {Brown, J.M. and Milton, D.J. and Watson, J.K.G. and Zare, R.N. and Albritton, D.L. and Horani, M. and Rostas, J.},
   date = {1981-11},
   journaltitle = {Journal of Molecular Spectroscopy},
@@ -72,7 +72,7 @@
 }
 
 @article{brownLambdaTypeDoublingParameters1979,
-  title = {Lambda-{{Type Doubling Parameters}} for {{Molecules}} in {{$\Pi$ Electronic States}} of {{Triplet}} and {{Higher Multiplicity}}},
+  title = {Lambda-{{Type Doubling Parameters}} for {{Molecules}} in {{Π Electronic States}} of {{Triplet}} and {{Higher Multiplicity}}},
   author = {Brown, J.M. and Merer, A.J.},
   date = {1979-03},
   journaltitle = {Journal of Molecular Spectroscopy},
@@ -88,7 +88,7 @@
 }
 
 @article{brownLTypeDoublingParameters1987,
-  title = {{$\Lambda$}-{{Type Doubling Parameters}} for {{Molecules}} in {{$\Delta$ Electronic States}}},
+  title = {Λ-{{Type Doubling Parameters}} for {{Molecules}} in {{Δ Electronic States}}},
   author = {Brown, J.M and Cheung, A.S-C and Merer, A.J},
   date = {1987-08},
   journaltitle = {Journal of Molecular Spectroscopy},
@@ -129,9 +129,9 @@
 }
 
 @article{cheungFourierTransformSpectroscopy1984,
-  title = {Fourier {{Transform Spectroscopy}} of {{CrO}}: {{Rotational Analysis}} of the {{{\mkbibemph{A}}}} {\textsuperscript{5}}{{$\Sigma$}}--{{{\mkbibemph{X}}}} {\textsuperscript{5}}{{$\Pi$}} (0,0) {{Band Near}} 8000 Cm{\textsuperscript{-1}}},
+  title = {Fourier {{Transform Spectroscopy}} of {{CrO}}: {{Rotational Analysis}} of the {{{\mkbibemph{A}}}} {\textsuperscript{5}}{{Σ}}–{{{\mkbibemph{X}}}} {\textsuperscript{5}}{{Π}} (0,0) {{Band Near}} 8000 Cm{\textsuperscript{−1}}},
   shorttitle = {Fourier Transform Spectroscopy of {{CrO}}},
-  author = {Cheung, A.S-C. and \.Zyrnicki, W. and Merer, A.J.},
+  author = {Cheung, A.S-C. and Żyrnicki, W. and Merer, A.J.},
   date = {1984-04},
   journaltitle = {Journal of Molecular Spectroscopy},
   shortjournal = {J. Mol. Spectrosc.},
@@ -146,8 +146,8 @@
 }
 
 @article{cheungMolecularSpectroscopicConstants1986,
-  title = {Molecular {{Spectroscopic Constants}} of {{O}}{\textsubscript{2}} ({{{\mkbibemph{B}}}} {\textsuperscript{3}}{{$\Sigma$}}{\textsuperscript{--}}): {{The Upper State}} of the {{Schumann}}--{{Runge Bands}}},
-  shorttitle = {Molecular Spectroscopic Constants of {{O2}}({{B3$\Sigma$}}-)},
+  title = {Molecular {{Spectroscopic Constants}} of {{O}}{\textsubscript{2}} ({{{\mkbibemph{B}}}} {\textsuperscript{3}}{{Σ}}{\textsuperscript{–}}): {{The Upper State}} of the {{Schumann}}–{{Runge Bands}}},
+  shorttitle = {Molecular Spectroscopic Constants of {{O2}}({{B3Σ}}−)},
   author = {Cheung, A.S.-C. and Yoshino, K. and Parkinson, W.H. and Freeman, D.E.},
   date = {1986-09},
   journaltitle = {Journal of Molecular Spectroscopy},
@@ -175,7 +175,7 @@
 
 @book{demtroderLaserSpectroscopy2008,
   title = {Laser {{Spectroscopy}}},
-  author = {Demtr\"oder, Wolfgang},
+  author = {Demtröder, Wolfgang},
   date = {2008},
   publisher = {Springer-Verlag Berlin Heidelberg},
   location = {Berlin, Germany},
@@ -187,7 +187,7 @@
 }
 
 @inproceedings{diskin3LevelModelSchumann1996,
-  title = {A 3-{{Level Model}} for {{Schumann}}--{{Runge O}}{\textsubscript{2}} {{Laser-Induced Fluorescence}}},
+  title = {A 3-{{Level Model}} for {{Schumann}}–{{Runge O}}{\textsubscript{2}} {{Laser-Induced Fluorescence}}},
   booktitle = {Fluid {{Dynamics Conference}}},
   author = {Diskin, Glenn and Lempert, Walter and Miles, Richard},
   date = {1996-06-17},
@@ -226,7 +226,7 @@
   title = {Spectroscopy and {{Optical Diagnostics}} for {{Gases}}},
   author = {Hanson, Ronald K. and Spearrin, R. Mitchell and Goldenstein, Christopher S.},
   date = {2016},
-  series = {{{SpringerLink B\"ucher}}},
+  series = {{{SpringerLink Bücher}}},
   publisher = {Springer},
   location = {Cham, Switzerland},
   doi = {10.1007/978-3-319-23252-2},
@@ -236,7 +236,7 @@
 }
 
 @mvbook{herzbergMolecularSpectraMolecular1950,
-  title = {Molecular {{Spectra}} and {{Molecular Structure}}: {{Volume I}} -- {{Spectra}} of {{Diatomic Molecules}}},
+  title = {Molecular {{Spectra}} and {{Molecular Structure}}: {{Volume I}} – {{Spectra}} of {{Diatomic Molecules}}},
   author = {Herzberg, Gerhard},
   date = {1950},
   edition = {2},
@@ -295,7 +295,7 @@
 @book{kovacsRotationalStructureSpectra1969,
   title = {Rotational {{Structure}} in the {{Spectra}} of {{Diatomic Molecules}}},
   shorttitle = {Rotational Structure in the Spectra of Diatomic Molecules},
-  author = {Kov\'acs, Istv\'an},
+  author = {Kovács, István},
   date = {1969},
   publisher = {Hilger},
   location = {London, England},
@@ -305,7 +305,7 @@
 }
 
 @article{lauxArraysRadiativeTransition1992,
-  title = {Arrays of {{Radiative Transition Probabilities}} for the {{N}}{\textsubscript{2}} {{First}} and {{Second Positive}}, {{NO Beta}} and {{Gamma}}, {{N}}{\textsubscript{2}}{\textsuperscript{+}} {{First Negative}}, and {{O}}{\textsubscript{2}} {{Schumann}}--{{Runge Band Systems}}},
+  title = {Arrays of {{Radiative Transition Probabilities}} for the {{N}}{\textsubscript{2}} {{First}} and {{Second Positive}}, {{NO Beta}} and {{Gamma}}, {{N}}{\textsubscript{2}}{\textsuperscript{+}} {{First Negative}}, and {{O}}{\textsubscript{2}} {{Schumann}}–{{Runge Band Systems}}},
   author = {Laux, Christophe O. and Kruger, Charles H.},
   date = {1992-07},
   journaltitle = {Journal of Quantitative Spectroscopy \& Radiative Transfer},
@@ -322,7 +322,7 @@
 
 @book{lefebvre-brionSpectraDynamicsDiatomic2004,
   title = {The {{Spectra}} and {{Dynamics}} of {{Diatomic Molecules}}},
-  author = {Lefebvre-Brion, H\'el\`ene and Field, Robert W.},
+  author = {Lefebvre-Brion, Hélène and Field, Robert W.},
   date = {2004},
   publisher = {Academic Press},
   doi = {10.1016/B978-0-12-441455-6.X5000-8},
@@ -343,7 +343,7 @@
 }
 
 @online{nistDiatomicSpectralDatabase2018,
-  title = {Diatomic {{Spectral Database}}, {\textsuperscript{3}}{{$\Sigma$-Ground State Molecules}}},
+  title = {Diatomic {{Spectral Database}}, {\textsuperscript{3}}{{Σ-Ground State Molecules}}},
   author = {NIST},
   date = {2018-04-26},
   url = {https://www.nist.gov/pml/diatomic-spectral-database/diatomic-spectral-database-3s-ground-state-molecules},
@@ -353,7 +353,7 @@
 }
 
 @online{nistDiatomicSpectralDatabase2018a,
-  title = {Diatomic {{Spectral Database}}, {\textsuperscript{1}}{{$\Sigma$-Ground State Molecules}}},
+  title = {Diatomic {{Spectral Database}}, {\textsuperscript{1}}{{Σ-Ground State Molecules}}},
   author = {NIST},
   date = {2018-04-24},
   url = {https://www.nist.gov/pml/diatomic-spectral-database/diatomic-spectral-database-1s-ground-state-molecules},
@@ -405,7 +405,7 @@
 }
 
 @article{tatumHonlLondonFactors1966,
-  title = {H\"onl--{{London Factors}} for {\textsuperscript{3}}{{$\Sigma$}}{\textsuperscript{\textpm}}--{\textsuperscript{3}}{{$\Sigma$}}{\textsuperscript{\textpm}} {{Transitions}}},
+  title = {Hönl–{{London Factors}} for {\textsuperscript{3}}{{Σ}}{\textsuperscript{±}}–{\textsuperscript{3}}{{Σ}}{\textsuperscript{±}} {{Transitions}}},
   author = {Tatum, J. B.},
   date = {1966-11-01},
   journaltitle = {Canadian Journal of Physics},

--- a/docs/gedisabres.tex
+++ b/docs/gedisabres.tex
@@ -27,7 +27,7 @@
 }
 
 % fontspec
-\newfontface\ipafont{Doulos SIL}[Contextuals={WordInitial,WordFinal}]
+\newfontface\ipafont{CMU Serif}
 
 % hyperref
 \hypersetup{

--- a/docs/gedisabres.tex
+++ b/docs/gedisabres.tex
@@ -1,7 +1,6 @@
+% !TeX program = lualatex
 \documentclass[11pt, twoside, fleqn]{report}
 
-% Load first to prevent errors of unknown origin.
-\usepackage{tipa}
 \usepackage[backend=biber, style=ieee]{biblatex}
 \usepackage[labelfont=bf]{caption}
 \usepackage[margin=1in]{geometry}
@@ -9,7 +8,7 @@
 \usepackage[version=4]{mhchem}
 \usepackage[parfill, skip=1em]{parskip}
 \usepackage[para]{threeparttable}
-\usepackage{amssymb, booktabs, derivative, fancyhdr, float, graphicx, microtype, multirow, natex, pgfplots, physics2, siunitx, tikz}
+\usepackage{booktabs, derivative, fancyhdr, float, graphicx, microtype, multirow, natex-lualatex, pgfplots, physics2, siunitx, tikz}
 % Must be loaded after amsmath.
 \usepackage[capitalize, nameinlink]{cleveref}
 % Must be loaded after xcolor.
@@ -105,13 +104,14 @@
             \draw[line width=1pt, peach] (p1) ++(1, 0) -- ++(0, 2);
             \draw[line width=1pt, yellow] (p1) ++(2, 0) -- ++(0, 3);
 
-            \draw[line width=1pt, green] (p1) ++(3.075, 0) -- ++(0, 1);
+            \draw[line width=1pt, green] (p1) ++(2.81, 0) -- ++(0, 1);
+            \draw[line width=1pt, green] (p2) ++(-2.81, 0) -- ++(0, 1);
 
             \draw[line width=1pt, sky] (p2) ++(-2, 0) -- ++(0, 3);
             \draw[line width=1pt, blue] (p2) ++(-1, 0) -- ++(0, 2);
             \draw[line width=1pt, lavender] (p2) -- ++(0, 1);
         \end{tikzpicture}\\
-        \textipa{/"dZEdaI "seIb\textrhookschwa z/}\\[2\baselineskip]
+        /ˈdʒɛdaɪ ˈseɪbɚz/\\[2\baselineskip]
         {\large\textit{\textcolor{red}{Ge}neralized \textcolor{peach}{Di}atomic \textcolor{yellow}{S}imulation for \textcolor{green}{Ab}sorption and \textcolor{sky}{R}ovibronic \\ \textcolor{blue}{E}mission \textcolor{lavender}{S}pectra}}\\[4\baselineskip]
         {\large Nathan G. Phillips}
 

--- a/docs/gedisabres.tex
+++ b/docs/gedisabres.tex
@@ -74,6 +74,9 @@
 % siunitx
 \DeclareSIUnit{\angstrom}{\text{Å}}
 
+% tikz
+\usetikzlibrary{calc}
+
 % custom
 \newcommand{\dash}{\!-\!}
 \newcommand{\state}[2]{\prescript{#1}{}{#2}}
@@ -89,15 +92,32 @@
     \rule{1pt}{\textheight}
     \hspace{0.05\textwidth}
     \parbox[b]{0.75\textwidth}{
+        \hspace{-10pt}
+        \begin{tikzpicture}
+            \node (title) at (0,0) {\Huge\textsc{GEDISABRES}};
 
-        {\Huge\textsc{GEDISABRES}}\\
+            \coordinate (p1) at ($(title.north west)+(0.2,0)$);
+            \coordinate (p2) at ($(title.north east)-(0.2,0)$);
+
+            \draw[line width=1pt] (p1) -- (p2);
+
+            \draw[line width=1pt, red] (p1) -- ++(0, 1);
+            \draw[line width=1pt, peach] (p1) ++(1, 0) -- ++(0, 2);
+            \draw[line width=1pt, yellow] (p1) ++(2, 0) -- ++(0, 3);
+
+            \draw[line width=1pt, green] (p1) ++(3.075, 0) -- ++(0, 1);
+
+            \draw[line width=1pt, sky] (p2) ++(-2, 0) -- ++(0, 3);
+            \draw[line width=1pt, blue] (p2) ++(-1, 0) -- ++(0, 2);
+            \draw[line width=1pt, lavender] (p2) -- ++(0, 1);
+        \end{tikzpicture}\\
         \textipa{/"dZEdaI "seIb\textrhookschwa z/}\\[2\baselineskip]
         {\large\textit{\textcolor{red}{Ge}neralized \textcolor{peach}{Di}atomic \textcolor{yellow}{S}imulation for \textcolor{green}{Ab}sorption and \textcolor{sky}{R}ovibronic \\ \textcolor{blue}{E}mission \textcolor{lavender}{S}pectra}}\\[4\baselineskip]
         {\large Nathan G. Phillips}
 
         \vspace{0.5\textheight}
 
-        {\noindent Texas A\&M University}\\[\baselineskip]
+        {\noindent \today}\\[\baselineskip]
     }
 
 \end{titlepage}

--- a/docs/gedisabres.tex
+++ b/docs/gedisabres.tex
@@ -1,6 +1,7 @@
-% !TeX program = lualatex
 \documentclass[11pt, twoside, fleqn]{report}
 
+% Load first to prevent errors of unknown origin.
+\usepackage{tipa}
 \usepackage[backend=biber, style=ieee]{biblatex}
 \usepackage[labelfont=bf]{caption}
 \usepackage[margin=1in]{geometry}
@@ -8,7 +9,7 @@
 \usepackage[version=4]{mhchem}
 \usepackage[parfill, skip=1em]{parskip}
 \usepackage[para]{threeparttable}
-\usepackage{amssymb, booktabs, derivative, fancyhdr, float, fontspec, graphicx, microtype, multirow, natex, pgfplots, physics2, siunitx, tikz}
+\usepackage{amssymb, booktabs, derivative, fancyhdr, float, graphicx, microtype, multirow, natex, pgfplots, physics2, siunitx, tikz}
 % Must be loaded after amsmath.
 \usepackage[capitalize, nameinlink]{cleveref}
 % Must be loaded after xcolor.
@@ -25,9 +26,6 @@
     \fancyfoot{}
     \fancyfoot[C]{\thepage}
 }
-
-% fontspec
-\newfontface\ipafont{CMU Serif}
 
 % hyperref
 \hypersetup{
@@ -93,7 +91,7 @@
     \parbox[b]{0.75\textwidth}{
 
         {\Huge\textsc{GEDISABRES}}\\
-        \ipafont{/ˈdʒɛdaɪ ˈseɪbɚz/}\\[2\baselineskip]
+        \textipa{/"dZEdaI "seIb\textrhookschwa z/}\\[2\baselineskip]
         {\large\textit{\textcolor{red}{Ge}neralized \textcolor{peach}{Di}atomic \textcolor{yellow}{S}imulation for \textcolor{green}{Ab}sorption and \textcolor{sky}{R}ovibronic \\ \textcolor{blue}{E}mission \textcolor{lavender}{S}pectra}}\\[4\baselineskip]
         {\large Nathan G. Phillips}
 

--- a/docs/gedisabres.tex
+++ b/docs/gedisabres.tex
@@ -8,7 +8,7 @@
 \usepackage[version=4]{mhchem}
 \usepackage[parfill, skip=1em]{parskip}
 \usepackage[para]{threeparttable}
-\usepackage{amssymb, booktabs, derivative, fancyhdr, float, graphicx, microtype, multirow, natex, pgfplots, physics2, siunitx, tikz}
+\usepackage{amssymb, booktabs, derivative, fancyhdr, float, fontspec, graphicx, microtype, multirow, natex, pgfplots, physics2, siunitx, tikz}
 % Must be loaded after amsmath.
 \usepackage[capitalize, nameinlink]{cleveref}
 % Must be loaded after xcolor.
@@ -25,6 +25,9 @@
     \fancyfoot{}
     \fancyfoot[C]{\thepage}
 }
+
+% fontspec
+\newfontface\ipafont{Doulos SIL}[Contextuals={WordInitial,WordFinal}]
 
 % hyperref
 \hypersetup{
@@ -89,7 +92,8 @@
     \hspace{0.05\textwidth}
     \parbox[b]{0.75\textwidth}{
 
-        {\Huge\textsc{GEDISABRES}}\\[2\baselineskip]
+        {\Huge\textsc{GEDISABRES}}\\
+        \ipafont{/ˈdʒɛdaɪ ˈseɪbɚz/}\\[2\baselineskip]
         {\large\textit{\textcolor{red}{Ge}neralized \textcolor{peach}{Di}atomic \textcolor{yellow}{S}imulation for \textcolor{green}{Ab}sorption and \textcolor{sky}{R}ovibronic \\ \textcolor{blue}{E}mission \textcolor{lavender}{S}pectra}}\\[4\baselineskip]
         {\large Nathan G. Phillips}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,4 @@ hamilterm = { git = "https://github.com/nategphillips/hamilterm", rev = "2dabd56
 py3nj = { git = "https://github.com/fujiisoup/py3nj", rev = "098e40e433d6c1f32b1b488519bbae40f40b812b" }
 
 [tool.uv]
-required-version = "==0.8.24"
+required-version = ">=0.9.1"

--- a/src/plot.py
+++ b/src/plot.py
@@ -132,7 +132,7 @@ def plot_line_info(
             wavelength: float = utils.wavenum_to_wavelen(line.wavenumber)
             intensity: float = line.intensity / max_intensity
             text: pg.TextItem = pg.TextItem(
-                f"ΔJ: {line.branch_name_j}{line.branch_idx_up}{line.branch_idx_lo}(J'={line.j_qn_up}, J''{line.j_qn_lo})\nΔN: {line.branch_name_n}{line.branch_idx_up}{line.branch_idx_lo}(N'={line.n_qn_up}, N''={line.n_qn_lo})",
+                f"ΔJ: {line.branch_name_j}{line.branch_idx_up}{line.branch_idx_lo}(J'={line.j_qn_up}, J''={line.j_qn_lo})\nΔN: {line.branch_name_n}{line.branch_idx_up}{line.branch_idx_lo}(N'={line.n_qn_up}, N''={line.n_qn_lo})",
                 color="w",
                 anchor=(0.5, 1.2),
             )

--- a/src/plot.py
+++ b/src/plot.py
@@ -16,17 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 import pyqtgraph as pg
 from numpy.typing import NDArray
 
 import utils
 from sim import Sim
-
-if TYPE_CHECKING:
-    from line import Line
 
 PEN_WIDTH: int = 1
 
@@ -133,14 +128,11 @@ def plot_line_info(
     plot_line(plot_widget, sim, colors, max_intensity, color_index)
 
     for band in sim.bands:
-        # Only select non-satellite lines to reduce the amount of data on screen.
-        lines: list[Line] = [line for line in band.lines if not line.is_satellite]
-
-        for line in lines:
+        for line in band.lines:
             wavelength: float = utils.wavenum_to_wavelen(line.wavenumber)
             intensity: float = line.intensity / max_intensity
             text: pg.TextItem = pg.TextItem(
-                f"ΔJ: {line.branch_name_j}_{line.branch_idx_up}{line.branch_idx_lo}",
+                f"ΔJ: {line.branch_name_j}{line.branch_idx_up}{line.branch_idx_lo}(J'={line.j_qn_up}, J''{line.j_qn_lo})\nΔN: {line.branch_name_n}{line.branch_idx_up}{line.branch_idx_lo}(N'={line.n_qn_up}, N''={line.n_qn_lo})",
                 color="w",
                 anchor=(0.5, 1.2),
             )


### PR DESCRIPTION
Changes:
- Transitions involving lambda doubled states (Π states) now have the correct branch indices.
- More (mostly aesthetic) updates to the documentation.